### PR TITLE
Updates to enable building of docker image and running container as module in mercure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN chmod -R 777 /opt/ants
 
 ADD . /
 
+RUN mkdir /data/1-input/
 RUN chmod -R 777 /data
 RUN chmod -R 777 /scripts
 RUN chmod -R 777 /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:bionic-20220427
 #as builder
-
+RUN chmod 777 /
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
                     apt-transport-https \
@@ -60,6 +60,7 @@ RUN chmod -R 777 /opt/ants
 #COPY --from=builder /opt/ants /opt/ants
 
 ADD . /
+
 RUN chmod -R 777 /data
 RUN chmod -R 777 /scripts
 RUN chmod -R 777 /src
@@ -103,6 +104,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 ADD ./src/build_tools/misc_io.py /opt/conda/envs/glioma-seg-37/lib/python3.7/site-packages/niftynet/io/misc_io.py
+RUN chmod 777 /opt/conda/envs/glioma-seg-37/lib/python3.7/site-packages/niftynet/io/misc_io.py
 # manage niftynet specific set up issues
 RUN mkdir /.niftynet && chmod -R 777 /.niftynet \
     && mkdir /niftynet && chmod -R 777 /niftynet
@@ -119,5 +121,5 @@ RUN pip3 uninstall tensorflow-gpu tensorflow
 #RUN pip3 install --user tensorflow-gpu~=1.12
 RUN pip3 install tensorflow-gpu~=1.12
 
-
+RUN chmod -R 777 /tmp
 CMD ["/scripts/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:bionic-20220427 as builder
+FROM ubuntu:bionic-20220427
+#as builder
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -12,25 +13,35 @@ RUN apt-get update \
                     software-properties-common \
                     wget
 
-RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+RUN wget --quiet -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
     | apt-key add - \
   && apt-add-repository -y 'deb https://apt.kitware.com/ubuntu/ bionic main' \
   && apt-get update \
   && apt-get -y install cmake=3.18.3-0kitware1 cmake-data=3.18.3-0kitware1
 
+
 ADD . /tmp/ants/source
+
+RUN git clone https://github.com/ANTsX/ANTs.git
+
+
+RUN cp -r ./ANTs/* /tmp/ants/source
+
+
+#ARG BUILD_SHARED_LIBS=ON
+
 RUN mkdir -p /tmp/ants/build \
     && cd /tmp/ants/build \
     && mkdir -p /opt/ants \
-    && git config --global url."https://".insteadOf git:// \
+    && git config --global url."https://".insteadOf "git://" \
     && cmake \
-      -GNinja \
-      -DBUILD_TESTING=ON \
-      -DRUN_LONG_TESTS=OFF \
-      -DRUN_SHORT_TESTS=ON \
-      -DBUILD_SHARED_LIBS=ON \
-      -DCMAKE_INSTALL_PREFIX=/opt/ants \
-      /tmp/ants/source \
+        -GNinja \
+        -DBUILD_TESTING=ON \
+        -DRUN_LONG_TESTS=OFF \
+        -DRUN_SHORT_TESTS=ON \
+        -DBUILD_SHARED_LIBS=ON \
+        -DCMAKE_INSTALL_PREFIX=/opt/ants \
+        /tmp/ants/source \
     && cmake --build . --parallel \
     && cd ANTS-build \
     && cmake --install .
@@ -41,8 +52,41 @@ ENV LD_LIBRARY_PATH="/opt/ants/lib:$LD_LIBRARY_PATH"
 RUN cd /tmp/ants/build/ANTS-build \
     && cmake --build . --target test
 
-FROM ubuntu:bionic-20220427
-COPY --from=builder /opt/ants /opt/ants
+#FROM ubuntu:bionic-20220427
+#COPY --from=builder /opt/ants /opt/ants
+#COPY --from=builder /opt/ants /opt/ants
+
+ADD . /
+RUN chmod -R 777 /data
+RUN chmod -R 777 /scripts
+RUN chmod -R 777 /src
+RUN chmod -R 777 /templates
+RUN chmod -R 777 /environment.yml
+
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y git build-essential cmake pigz
+RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y libsm6 libxrender-dev libxext6 ffmpeg 
+RUN apt-get install unzip
+RUN apt-get install -y wget
+
+RUN wget --quiet -O /tmp/miniconda.sh https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+# install miniconda
+ARG CONDA_DIR=/opt/conda
+ENV PATH $CONDA_DIR/bin:$PATH
+RUN bash /tmp/miniconda.sh -b -p $CONDA_DIR
+RUN rm -rf /tmp/*
+
+
+RUN conda create -n env python=3.7
+RUN echo "source activate env" > ~/.bashrc
+ENV PATH /opt/conda/envs/env/bin:$PATH
+RUN chmod -R 777 /opt/conda/envs
+
+RUN conda env create -f ./environment.yml
+
+# Pull the environment name out of the environment.yml
+RUN echo "source activate $(head -1 ./environment.yml | cut -d' ' -f2)" > ~/.bashrc
+#ENV PATH /opt/conda/envs/$(head -1 ./environment.yml | cut -d' ' -f2)/bin:$PATH
+ENV PATH /opt/conda/envs/$(head -1 ./environment.yml | cut -d' ' -f2)/bin:$PATH
 
 LABEL maintainer="ANTsX team" \
       description="ANTs is part of the ANTsX ecosystem (https://github.com/ANTsX). \
@@ -55,25 +99,22 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# copy working directory with model code into image
-COPY . ./
-
-# install miniconda
-ARG CONDA_DIR=/opt/miniconda
-ENV PATH $CONDA_DIR/bin:$PATH
-RUN wget --quiet https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda.sh && \
-    bash /tmp/miniconda.sh -b -p $CONDA_DIR && \
-    rm -rf /tmp/*
-
-# create conda env based on our environment file
-RUN $CONDA_DIR/bin/conda env create -f environment.yml
-
+ADD ./src/build_tools/misc_io.py /opt/conda/envs/glioma-seg-37/lib/python3.7/site-packages/niftynet/io/misc_io.py
 # manage niftynet specific set up issues
-RUN cp ./src/build_tools/misc_io.py /opt/miniconda/envs/glioma-seg-37/lib/python3.7/site-packages/niftynet/io/misc_io.py && \
-    mkdir /.niftynet && chmod -R 777 /.niftynet && \
-    mkdir /niftynet && chmod -R 777 /niftynet
+RUN mkdir /.niftynet && chmod -R 777 /.niftynet \
+    && mkdir /niftynet && chmod -R 777 /niftynet
+
 
 # run entrypoint with conda environment
-RUN chmod 777 ./scripts/docker-entrypoint.sh && \
-    chmod -R 777 /models/msnet/model19_prepost4s/
-ENTRYPOINT ["conda", "run", "-n", "glioma-seg-37", "/scripts/docker-entrypoint.sh"]
+RUN chmod 777 /scripts/docker-entrypoint.sh && \
+    chmod -R 777 /src/models/msnet/model19_prepost4s/
+
+RUN pip3 uninstall protobuf
+#RUN pip3 install --user protobuf==3.20
+RUN pip3 install protobuf==3.20
+RUN pip3 uninstall tensorflow-gpu tensorflow
+#RUN pip3 install --user tensorflow-gpu~=1.12
+RUN pip3 install tensorflow-gpu~=1.12
+
+
+CMD ["/scripts/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,9 @@ ENV LD_LIBRARY_PATH="/opt/ants/lib:$LD_LIBRARY_PATH"
 RUN cd /tmp/ants/build/ANTS-build \
     && cmake --build . --target test
 
+
+RUN chmod -R 777 /tmp/ants
+RUN chmod -R 777 /opt/ants
 #FROM ubuntu:bionic-20220427
 #COPY --from=builder /opt/ants /opt/ants
 #COPY --from=builder /opt/ants /opt/ants

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: glioma-seg-37
 channels:
   - anaconda
   - defaults
+  - conda-forge
 dependencies:
   - _libgcc_mutex=0.1=main
   - _openmp_mutex=5.1=1_gnu
@@ -25,6 +26,7 @@ dependencies:
   - wheel=0.37.1=pyhd3eb1b0_0
   - xz=5.2.6=h5eee18b_0
   - zlib=1.2.13=h5eee18b_0
+  - dcm2niix
   - pip:
     - absl-py==1.3.0
     - astor==0.8.1
@@ -50,7 +52,7 @@ dependencies:
     - packaging==21.3
     - pandas==1.1.5
     - pillow==9.3.0
-    - protobuf==3.20.3
+    - protobuf==3.20 #.3
     - pyparsing==3.0.9
     - python-dateutil==2.8.2
     - pytz==2022.6

--- a/scripts/ants_coreg.sh
+++ b/scripts/ants_coreg.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
 dim=3 # image dimensionality
-AP="/home/amritha/workspace/antsbin/ANTS-build/Examples/" # path to ANTs binaries
+#AP="/home/amritha/workspace/antsbin/ANTS-build/Examples/" # path to ANTs binaries
+AP="/home/vagrant/ANTs/bin/"
 ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2  # controls multi-threading
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
 f=$1 ; m=$2    # fixed and moving image file names

--- a/scripts/ants_coreg.sh
+++ b/scripts/ants_coreg.sh
@@ -2,7 +2,8 @@
 #
 dim=3 # image dimensionality
 #AP="/home/amritha/workspace/antsbin/ANTS-build/Examples/" # path to ANTs binaries
-AP="/home/vagrant/ANTs/bin/"
+#AP="/home/vagrant/ANTs/bin/"
+AP="/opt/ants/bin/"
 ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS=2  # controls multi-threading
 export ITK_GLOBAL_DEFAULT_NUMBER_OF_THREADS
 f=$1 ; m=$2    # fixed and moving image file names

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -Eeo pipefail
 echo "-- Starting module..."
-ls /models/msnet/model19_prepost4s/
+ls /src/models/msnet/model19_prepost4s/
 
 cp -r $MERCURE_IN_DIR/* data/1-input/
 
-python3 -m src.run_pipeline \
+conda run -n glioma-seg-37 python3 -m src.run_pipeline \
 
 cp -r data/6-output/* $MERCURE_OUT_DIR/
 

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -7,6 +7,6 @@ cp -r $MERCURE_IN_DIR/* data/1-input/
 
 conda run -n glioma-seg-37 python3 -m src.run_pipeline \
 
-cp -r data/6-output/* $MERCURE_OUT_DIR/
+cp -rp data/6-output/* $MERCURE_OUT_DIR/
 
 echo "-- Done."

--- a/src/models/segmentation.py
+++ b/src/models/segmentation.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import os
 import csv
+import stat
+from pathlib import Path
 
 from src.models.msnet.inference import run_inference
 
@@ -8,12 +10,14 @@ def run_msnet_segmentation(input_dir, output_dir):
     
     if not os.path.exists(os.path.join(input_dir, "patient")):
         os.makedirs(os.path.join(input_dir, "patient"))
+        p = Path(os.path.join(input_dir, "patient"))
+        p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
     os.system(f"mv {input_dir}/*.nii.gz {input_dir}/patient/")
 
     config_file = Path("src/models/msnet/config/mercure_config.txt")
 
     tumor_volume = run_inference(input_dir, output_dir, config_file)
-
+    print("inference completed")
     os.system(f"mv {input_dir}/patient/*.nii.gz {input_dir}/")
 
     os.system(f"mv {output_dir}/patient/patient_seg_edema.nii.gz {output_dir}/seg_edema.nii.gz")
@@ -31,5 +35,5 @@ def run_msnet_segmentation(input_dir, output_dir):
         writer = csv.writer(f)
         for key, val in tumor_volume.items():
             writer.writerow([key, val])
-
+    print("inference outputs written")
     return tumor_volume

--- a/src/postprocessing/postprocess.py
+++ b/src/postprocessing/postprocess.py
@@ -73,7 +73,7 @@ def arr2dicom(
      #--update
     ds.is_little_endian=True
     ds.is_implicit_VR=False
-    ds.is_original_encoding=False
+    #ds.is_original_encoding=False
 
     ds.add_new(0x00280006, 'US', 0)
     ds.fix_meta_info() 

--- a/src/postprocessing/postprocess.py
+++ b/src/postprocessing/postprocess.py
@@ -6,6 +6,8 @@ from enum import IntEnum
 from pathlib import Path
 from typing import Generator
 import os
+import stat
+from pathlib import Path
 
 import cv2
 import numpy as np
@@ -45,32 +47,42 @@ def arr2dicom(
     # adjust the shape of the DICOM image to match the masked slice
     ds.Rows = arr.shape[0]
     ds.Columns = arr.shape[1]
+    # adjust the expected range of pixels in the image data, we have normalized to 0-255
+    # this is information DICOM viewers use to adjust brightness/constrast for display
+    ds.WindowCenter = 128
+    ds.WindowWidth = 256
+    ds.ImageOrientationPatient = [1, 0, 0, 0, 1, 0]
+    # tag which slice in the volume we're dealing with
+    ds.ImagePositionPatient = [0, 0, slice_idx]
+    ds.InstanceNumber = slice_idx + 1
 
+    # specify transfer syntax to assign pixel data
+    ds.file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
+    #ds.file_meta.TransferSyntaxUID = pydicom.uid.ImplicitVRLittleEndian
+     
     # assign values for a color DICOM instead of a grayscale
     ds.PhotometricInterpretation = "RGB"
     ds.SamplesPerPixel = 3
     ds.BitsAllocated = 8
     ds.BitsStored = 8
     ds.HighBit = 7
-    ds.PixelRepresentation = 0
-    ds.PlanarConfiguration = 0
+    #ds.PixelRepresentation = 0
+    #ds.PlanarConfiguration = 0
+    #--update
+    
+     #--update
+    ds.is_little_endian=True
+    ds.is_implicit_VR=False
+    ds.is_original_encoding=False
 
-    # adjust the expected range of pixels in the image data, we have normalized to 0-255
-    # this is information DICOM viewers use to adjust brightness/constrast for display
-    ds.WindowCenter = 128
-    ds.WindowWidth = 256
-
-    # specify transfer syntax to assign pixel data
-    ds.file_meta.TransferSyntaxUID = pydicom.uid.ExplicitVRLittleEndian
+    ds.add_new(0x00280006, 'US', 0)
+    ds.fix_meta_info() 
+    
 
     # copy the array containing the masked slice image to pixel data
     ds.PixelData = arr.tobytes()
-    ds.ImageOrientationPatient = [1, 0, 0, 0, 1, 0]
-
-    # tag which slice in the volume we're dealing with
-    ds.ImagePositionPatient = [0, 0, slice_idx]
-    ds.InstanceNumber = slice_idx + 1
-
+    ds.ImageType = "DERIVED\\SECONDARY"
+    
     return ds
 
 
@@ -151,6 +163,8 @@ def nifti2dicom(
             ".dcm"
         )
         output_dicom_file.save_as(output_filename)
+        #p = Path(output_filename)
+        #p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
 
 
 def masked2dicom(
@@ -210,7 +224,8 @@ def masked2dicom(
             ".dcm"
         )
         output_dicom_file.save_as(output_filename)
-
+        #p = Path(output_filename)
+        #p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
 
 def merge3D_mask_arr(
     mask_arr: np.ndarray,
@@ -481,7 +496,7 @@ def postprocess(
     """
 
     mask_path = list(Path(mask_dir).glob("*_whole.nii.gz"))[0]
-
+    print("starting nifti to dicom")
     nifti2dicom(
         mask_path,
         dicom_source_file,

--- a/src/preprocessing/coreg.py
+++ b/src/preprocessing/coreg.py
@@ -1,5 +1,6 @@
 import os
-
+import stat
+from pathlib import Path
 
 def ants_coreg(fixed_nifti, moving_nifti, setting):
     """Coregister two NIfTI files using ANTs.
@@ -27,6 +28,8 @@ def coreg(nifti_dir, coreg_dir):
     for modality in modalities:
         if modality == 't1ce':
             os.system(f"cp {os.path.join(nifti_dir, 'brain_t1ce.nii.gz')} {os.path.join(coreg_dir, 'brain_t1ce.nii.gz')}")
+            p = Path(os.path.join(coreg_dir, 'brain_t1ce.nii.gz'))
+            p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
         else:
             fixed_nifti = os.path.join(nifti_dir, 'brain_t1ce.nii.gz')
             moving_nifti = os.path.join(nifti_dir, f'brain_{modality}.nii.gz')
@@ -35,6 +38,8 @@ def coreg(nifti_dir, coreg_dir):
             # move coregistered file to coreg_dir
             registered_nifti = [file for file in os.listdir('.') if modality in file and file.endswith('_warped.nii.gz')][0]
             os.rename(registered_nifti, os.path.join(coreg_dir, f'brain_{modality}.nii.gz'))
+            p = Path(os.path.join(coreg_dir, f'brain_{modality}.nii.gz'))
+            p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
 
             # remove intermediate files
             os.system("rm *.nii.gz")

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -69,7 +69,15 @@ def run_pipeline(base_dir):
         # select a DICOM file to use as a template
         dcm_source_file = os.listdir(input_dir)[0]
         dcm_source_file = os.path.join(input_dir, dcm_source_file)
+        print("postprocessing started")
         postprocess(nifti_dir, coreg_dir, seg_dir, output_dir, dcm_source_file, tumor_volume)
+
+    #set permissions for output files
+    for root, dirs, files in os.walk(output_dir):
+        for d in dirs:
+            os.chmod(os.path.join(root, d), 0o777)
+        for f in files:
+            os.chmod(os.path.join(root, f), 0o777)
 
     end = time.time()
 

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -66,4 +66,5 @@ def run_pipeline(base_dir):
 
 if __name__ == "__main__":
     #run_pipeline("/home/amritha/workspace/coreg-skull-strip-testing/data/")
-    run_pipeline("/home/vagrant/MSNet-pipeline/data/")
+    #run_pipeline("/home/vagrant/MSNet-pipeline/data/")
+    run_pipeline("/data/")

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -6,6 +6,8 @@ from src.postprocessing.postprocess import postprocess
 import os
 import csv
 import time
+import stat
+from pathlib import Path
 
 def run_pipeline(base_dir):
     """Run the full pipeline, preprocessing, segmentation, postprocessing."""
@@ -22,24 +24,32 @@ def run_pipeline(base_dir):
     # convert DICOM files to NIfTi
     if not os.path.exists(nifti_dir):
         os.makedirs(nifti_dir)
+        p = Path(nifti_dir)
+        p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
     if len(os.listdir(nifti_dir)) == 0:
         convert_dicom_to_nifti(input_dir, nifti_dir)
 
     # coregister
     if not os.path.exists(coreg_dir):
         os.makedirs(coreg_dir)
+        p = Path(coreg_dir)
+        p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
     if len(os.listdir(coreg_dir)) == 0:
         coreg(nifti_dir, coreg_dir)
 
     # skull strip
     if not os.path.exists(skullstrip_dir):
         os.makedirs(skullstrip_dir)
+        p = Path(skullstrip_dir)
+        p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
     if len(os.listdir(skullstrip_dir)) == 0:
         skull_strip(coreg_dir, skullstrip_dir)
 
     # glioma segmentation
     if not os.path.exists(seg_dir):
         os.makedirs(seg_dir)
+        p = Path(seg_dir)
+        p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
     if len(os.listdir(seg_dir)) == 0:
         tumor_volume = run_msnet_segmentation(skullstrip_dir, seg_dir)
     else:
@@ -53,6 +63,8 @@ def run_pipeline(base_dir):
     # nifti to dicom
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
+        p = Path(output_dir)
+        p.chmod(p.stat().st_mode | stat.S_IROTH | stat.S_IXOTH | stat.S_IWOTH)
     if len(os.listdir(output_dir)) == 0:
         # select a DICOM file to use as a template
         dcm_source_file = os.listdir(input_dir)[0]

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -23,7 +23,7 @@ def run_pipeline(base_dir):
     if not os.path.exists(nifti_dir):
         os.makedirs(nifti_dir)
     if len(os.listdir(nifti_dir)) == 0:
-            convert_dicom_to_nifti(input_dir, nifti_dir)
+        convert_dicom_to_nifti(input_dir, nifti_dir)
 
     # coregister
     if not os.path.exists(coreg_dir):
@@ -65,4 +65,5 @@ def run_pipeline(base_dir):
     print("RUNTIME:", end - start)
 
 if __name__ == "__main__":
-    run_pipeline("/home/amritha/workspace/coreg-skull-strip-testing/data/")
+    #run_pipeline("/home/amritha/workspace/coreg-skull-strip-testing/data/")
+    run_pipeline("/home/vagrant/MSNet-pipeline/data/")


### PR DESCRIPTION
closes #2 

This PR updates code in the dockerfile and environment.yml file so that a docker image will be generated without errors and will run as a module in mercure DICOM orchestrator as intended.

Code had been added so that 'modalities' selected in dcm_to_nii.py can be set using the task.json file in mercure enabling users to modify selected modalities via the web interface. The settings will default to the values in the enums.py file as in the original code.

The docker image has been built and tested successfully with mercure, the module has also been tested in a processing chain with the mercure-anonymizer module inside mercure.
